### PR TITLE
refactor: Rename isMultiOutcome to isNegRisk and feeRateBps input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@predictdotfun/sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "description": "A TypeScript SDK to help developers interface with the Predict's protocol.",
   "homepage": "https://predict.fun/",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
-import type { Addresses, OrderConfig } from "./Types";
+import type { Addresses } from "./Types";
 import { JsonRpcProvider } from "ethers";
 
 export const MAX_SALT = 2_147_483_648;
@@ -44,18 +44,6 @@ export const ProviderByChainId = {
   [ChainId.BlastMainnet]: new JsonRpcProvider("https://rpc.blast.io/"),
   [ChainId.BlastSepolia]: new JsonRpcProvider("https://sepolia.blast.io/"),
 } satisfies Record<ChainId, JsonRpcProvider>;
-
-/**
- * @remarks The fee rate is only applied on the taker's side.
- */
-export const OrderConfigByChainId = {
-  [ChainId.BlastMainnet]: {
-    feeRateBps: "50",
-  },
-  [ChainId.BlastSepolia]: {
-    feeRateBps: "50",
-  },
-} satisfies Record<ChainId, OrderConfig>;
 
 export const PROTOCOL_NAME = "predict.fun CTF Exchange";
 export const PROTOCOL_VERSION = "1";

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -33,11 +33,11 @@ export class FailedTypedDataEncoderError extends Error {
   }
 }
 
-export class InvalidMultiOutcomeConfig extends Error {
-  public readonly name = "InvalidMultiOutcomeConfig";
+export class InvalidNegRiskConfig extends Error {
+  public readonly name = "InvalidNegRiskConfig";
   constructor() {
     super(
-      "The token ID of one or more orders is not registered in the selected contract. Use `cancelOrder` when `isMultiOutcome` is true. Otherwise, use `cancelNegRiskOrder`.",
+      "The token ID of one or more orders is not registered in the selected contract. Use `cancelOrders` when `isNegRisk` is false. Otherwise, use `cancelNegRiskOrders`.",
     );
   }
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -46,10 +46,6 @@ export interface OrderAmounts {
  * Configuration
  */
 
-export interface OrderConfig {
-  feeRateBps: BigIntString;
-}
-
 export interface Addresses {
   CTF_EXCHANGE: string;
   NEG_RISK_CTF_EXCHANGE: string;
@@ -155,12 +151,13 @@ export interface BuildOrderInput {
   tokenId: Order["tokenId"] | bigint;
   makerAmount: Order["makerAmount"] | bigint;
   takerAmount: Order["takerAmount"] | bigint;
+  /* The current fee rate should be fetched via the `GET /markets` endpoint */
+  feeRateBps: Order["feeRateBps"] | bigint | number;
   nonce?: Order["nonce"] | bigint;
   salt?: Order["salt"] | bigint;
   maker?: Order["maker"];
   taker?: Order["taker"];
   signatureType?: Order["signatureType"];
-  feeRateBps?: Order["feeRateBps"] | bigint | number;
   expiresAt?: Date;
 }
 
@@ -297,7 +294,7 @@ export type TransactionResult = TransactionSuccess | TransactionFail;
 
 export interface CancelOrdersInput {
   orders: SignedOrder[];
-  isMultiOutcome: boolean;
+  isNegRisk: boolean;
 }
 
 export interface CancelOrdersOptions {

--- a/tests/OrderBuilder.test.ts
+++ b/tests/OrderBuilder.test.ts
@@ -97,6 +97,7 @@ describe("OrderBuilder", () => {
         tokenId: "123",
         makerAmount: toWei(10),
         takerAmount: toWei(5),
+        feeRateBps: 0,
       });
 
       expect(order.salt).toBe("1234");
@@ -120,6 +121,7 @@ describe("OrderBuilder", () => {
         tokenId: "456",
         makerAmount: toWei(5),
         takerAmount: toWei(10),
+        feeRateBps: 0,
       });
 
       expect(order.salt).toBe("1234");
@@ -146,6 +148,7 @@ describe("OrderBuilder", () => {
           makerAmount: toWei(10),
           takerAmount: toWei(5),
           expiresAt: new Date("2024-01-01T00:00:00Z"),
+          feeRateBps: 0,
         }),
       ).toThrow(InvalidExpirationError);
     });
@@ -160,9 +163,10 @@ describe("OrderBuilder", () => {
         tokenId: "123",
         makerAmount: toWei(10),
         takerAmount: toWei(5),
+        feeRateBps: 0,
       });
 
-      const typedData = orderBuilder.buildTypedData(order, false);
+      const typedData = orderBuilder.buildTypedData(order, { isNegRisk: false });
 
       expect(typedData.primaryType).toBe("Order");
       expect(typedData.domain.name).toBe("predict.fun CTF Exchange");
@@ -180,9 +184,10 @@ describe("OrderBuilder", () => {
         tokenId: "123",
         makerAmount: toWei(10),
         takerAmount: toWei(5),
+        feeRateBps: 0,
       });
 
-      const typedData = orderBuilder.buildTypedData(order, false);
+      const typedData = orderBuilder.buildTypedData(order, { isNegRisk: false });
       const signedOrder = await orderBuilder.signTypedDataOrder(typedData);
 
       expect(signedOrder).toEqual({
@@ -200,9 +205,10 @@ describe("OrderBuilder", () => {
         tokenId: "123",
         makerAmount: toWei(10),
         takerAmount: toWei(5),
+        feeRateBps: 0,
       });
 
-      const typedData = orderBuilderWithoutSigner.buildTypedData(order, false);
+      const typedData = orderBuilderWithoutSigner.buildTypedData(order, { isNegRisk: false });
 
       await expect(orderBuilderWithoutSigner.signTypedDataOrder(typedData)).rejects.toThrow(MissingSignerError);
     });
@@ -217,9 +223,10 @@ describe("OrderBuilder", () => {
         tokenId: "123",
         makerAmount: toWei(10),
         takerAmount: toWei(5),
+        feeRateBps: 0,
       });
 
-      const typedData = orderBuilder.buildTypedData(order, false);
+      const typedData = orderBuilder.buildTypedData(order, { isNegRisk: false });
       const hash = orderBuilder.buildTypedDataHash(typedData);
 
       expect(typeof hash).toBe("string");


### PR DESCRIPTION
- Rename `isMultiOutcome` to `isNegRisk`
- Make `feeRateBps` a mandatory field when building the order (should be fetched via the REST API)
- Fix some typos and comments