### PR TITLE
feat: Add utils for Predict accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@predictdotfun/sdk",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "A TypeScript SDK to help developers interface with the Predict's protocol.",
   "homepage": "https://predict.fun/",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,5 @@
 import type { Addresses } from "./Types";
+import type { TypedDataDomain } from "ethers";
 import { JsonRpcProvider } from "ethers";
 
 export const MAX_SALT = 2_147_483_648;
@@ -23,6 +24,11 @@ export enum Side {
   SELL = 1,
 }
 
+export const KernelDomainByChainId = {
+  [ChainId.BlastMainnet]: { name: "Kernel", version: "0.3.1", chainId: ChainId.BlastMainnet },
+  [ChainId.BlastSepolia]: { name: "Kernel", version: "0.3.1", chainId: ChainId.BlastSepolia },
+} satisfies Record<ChainId, TypedDataDomain>;
+
 export const AddressesByChainId = {
   [ChainId.BlastMainnet]: {
     CTF_EXCHANGE: "0x739f0331594029064C252559436eDce0E468E37a",
@@ -30,6 +36,8 @@ export const AddressesByChainId = {
     NEG_RISK_ADAPTER: "0xc55687812285D05b74815EE2716D046fAF61B003",
     CONDITIONAL_TOKENS: "0x8F9C9f888A4268Ab0E2DDa03A291769479bAc285",
     USDB: "0x4300000000000000000000000000000000000003",
+    KERNEL: "0xBAC849bB641841b44E965fB01A4Bf5F074f84b4D",
+    ECDSA_VALIDATOR: "0x845ADb2C711129d4f3966735eD98a9F09fC4cE57",
   },
   [ChainId.BlastSepolia]: {
     CTF_EXCHANGE: "0xba9605D6d0108ed3787fD9423F6d28BF8c7dE2DD",
@@ -37,6 +45,8 @@ export const AddressesByChainId = {
     NEG_RISK_ADAPTER: "0xd21Ce3f6A0e9351bF47b9045200410f55F74f9CC",
     CONDITIONAL_TOKENS: "0xD6EBc6E01a282A3803920DE31227D8a6687e2F8F",
     USDB: "0x4200000000000000000000000000000000000022",
+    KERNEL: "0xBAC849bB641841b44E965fB01A4Bf5F074f84b4D",
+    ECDSA_VALIDATOR: "0x845ADb2C711129d4f3966735eD98a9F09fC4cE57",
   },
 } satisfies Record<ChainId, Addresses>;
 

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -41,3 +41,19 @@ export class InvalidNegRiskConfig extends Error {
     );
   }
 }
+
+export class MakerSignerMismatchError extends Error {
+  public readonly name = "MakerSignerMismatchError";
+  constructor() {
+    super("The maker and signer must be the same address.");
+  }
+}
+
+export class InvalidSignerError extends Error {
+  public readonly name = "InvalidSignerError";
+  constructor() {
+    super(
+      "The signer is not the owner of the Predict account or you are on the wrong chain. The signer must be the Privy wallet exported from your account's settings. See: https://predict.fun/account/settings",
+    );
+  }
+}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -4,11 +4,14 @@ import type {
   BlastCTFExchange,
   BlastNegRiskAdapter,
   BlastNegRiskCtfExchange,
+  ECDSAValidator,
   ERC20,
+  Kernel,
 } from "./typechain";
-import type { ContractTransactionReceipt } from "ethers";
+import type { ContractTransactionReceipt, Interface } from "ethers";
 
 export type BigIntString = string;
+export type Address = string;
 
 export type Currency = "USDB";
 export type OrderStrategy = "MARKET" | "LIMIT";
@@ -47,11 +50,13 @@ export interface OrderAmounts {
  */
 
 export interface Addresses {
-  CTF_EXCHANGE: string;
-  NEG_RISK_CTF_EXCHANGE: string;
-  NEG_RISK_ADAPTER: string;
-  CONDITIONAL_TOKENS: string;
-  USDB: string;
+  CTF_EXCHANGE: Address;
+  NEG_RISK_CTF_EXCHANGE: Address;
+  NEG_RISK_ADAPTER: Address;
+  CONDITIONAL_TOKENS: Address;
+  USDB: Address;
+  KERNEL: Address;
+  ECDSA_VALIDATOR: Address;
 }
 
 /**
@@ -147,12 +152,12 @@ export interface SignedOrder extends Order {
 
 export interface BuildOrderInput {
   side: Order["side"];
-  signer: Order["signer"];
   tokenId: Order["tokenId"] | bigint;
   makerAmount: Order["makerAmount"] | bigint;
   takerAmount: Order["takerAmount"] | bigint;
   /* The current fee rate should be fetched via the `GET /markets` endpoint */
   feeRateBps: Order["feeRateBps"] | bigint | number;
+  signer?: Order["signer"];
   nonce?: Order["nonce"] | bigint;
   salt?: Order["salt"] | bigint;
   maker?: Order["maker"];
@@ -205,11 +210,13 @@ export interface Book {
  */
 
 export interface Contracts {
-  CTF_EXCHANGE: BlastCTFExchange;
-  NEG_RISK_CTF_EXCHANGE: BlastNegRiskCtfExchange;
-  NEG_RISK_ADAPTER: BlastNegRiskAdapter;
-  CONDITIONAL_TOKENS: BlastConditionalTokens;
-  USDB: ERC20;
+  CTF_EXCHANGE: { contract: BlastCTFExchange; codec: Interface };
+  NEG_RISK_CTF_EXCHANGE: { contract: BlastNegRiskCtfExchange; codec: Interface };
+  NEG_RISK_ADAPTER: { contract: BlastNegRiskAdapter; codec: Interface };
+  CONDITIONAL_TOKENS: { contract: BlastConditionalTokens; codec: Interface };
+  USDB: { contract: ERC20; codec: Interface };
+  KERNEL: { contract: Kernel; codec: Interface };
+  ECDSA_VALIDATOR: { contract: ECDSAValidator; codec: Interface };
 }
 
 export interface MulticallContracts extends Contracts {

--- a/src/abis/ECDSAValidator.json
+++ b/src/abis/ECDSAValidator.json
@@ -1,0 +1,279 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "smartAccount",
+        "type": "address"
+      }
+    ],
+    "name": "AlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidTargetAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "smartAccount",
+        "type": "address"
+      }
+    ],
+    "name": "NotInitialized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "kernel",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerRegistered",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "ecdsaValidatorStorage",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "smartAccount",
+        "type": "address"
+      }
+    ],
+    "name": "isInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "typeID",
+        "type": "uint256"
+      }
+    ],
+    "name": "isModuleType",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "hash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "sig",
+        "type": "bytes"
+      }
+    ],
+    "name": "isValidSignatureWithSender",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onInstall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onUninstall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "hookData",
+        "type": "bytes"
+      }
+    ],
+    "name": "postCheck",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "msgSender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "preCheck",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "initCode",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "accountGasLimits",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "preVerificationGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "gasFees",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "paymasterAndData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PackedUserOperation",
+        "name": "userOp",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "userOpHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "validateUserOp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/src/abis/Kernel.json
+++ b/src/abis/Kernel.json
@@ -1,0 +1,1224 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IEntryPoint",
+        "name": "_entrypoint",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "EnableNotApproved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExecutionReverted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "idx",
+        "type": "uint256"
+      }
+    ],
+    "name": "InitConfigError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidCallType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidCaller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidExecutor",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidFallback",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidMode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidModuleType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidNonce",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSelector",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidValidationType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidValidator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NonceInvalidationError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotSupportedCallType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyExecuteUserOp",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PermissionDataLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PermissionNotAlllowedForSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PermissionNotAlllowedForUserOp",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PolicyDataTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "i",
+        "type": "uint256"
+      }
+    ],
+    "name": "PolicyFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PolicySignatureOrderError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RootValidatorCannotBeRemoved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SignerPrefixNotPresent",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "moduleTypeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      }
+    ],
+    "name": "ModuleInstalled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "result",
+        "type": "bool"
+      }
+    ],
+    "name": "ModuleUninstallResult",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "moduleTypeId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      }
+    ],
+    "name": "ModuleUninstalled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "nonce",
+        "type": "uint32"
+      }
+    ],
+    "name": "NonceInvalidated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "PermissionId",
+        "name": "permission",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "nonce",
+        "type": "uint32"
+      }
+    ],
+    "name": "PermissionInstalled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "PermissionId",
+        "name": "permission",
+        "type": "bytes4"
+      }
+    ],
+    "name": "PermissionUninstalled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Received",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "ValidationId",
+        "name": "rootValidator",
+        "type": "bytes21"
+      }
+    ],
+    "name": "RootValidatorUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "ValidationId",
+        "name": "vId",
+        "type": "bytes21"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "SelectorSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "batchExecutionindex",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "result",
+        "type": "bytes"
+      }
+    ],
+    "name": "TryExecuteUnsuccessful",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IValidator",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "nonce",
+        "type": "uint32"
+      }
+    ],
+    "name": "ValidatorInstalled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IValidator",
+        "name": "validator",
+        "type": "address"
+      }
+    ],
+    "name": "ValidatorUninstalled",
+    "type": "event"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [],
+    "name": "accountId",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "accountImplementationId",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ValidationId",
+        "name": "_rootValidator",
+        "type": "bytes21"
+      },
+      {
+        "internalType": "contract IHook",
+        "name": "hook",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "validatorData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "hookData",
+        "type": "bytes"
+      }
+    ],
+    "name": "changeRootValidator",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentNonce",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "entrypoint",
+    "outputs": [
+      {
+        "internalType": "contract IEntryPoint",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ExecMode",
+        "name": "execMode",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "executionCalldata",
+        "type": "bytes"
+      }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ExecMode",
+        "name": "execMode",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "executionCalldata",
+        "type": "bytes"
+      }
+    ],
+    "name": "executeFromExecutor",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "returnData",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "initCode",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "accountGasLimits",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "preVerificationGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "gasFees",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "paymasterAndData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PackedUserOperation",
+        "name": "userOp",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "userOpHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "executeUserOp",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IExecutor",
+        "name": "executor",
+        "type": "address"
+      }
+    ],
+    "name": "executorConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IHook",
+            "name": "hook",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct ExecutorManager.ExecutorConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ValidationId",
+        "name": "_rootValidator",
+        "type": "bytes21"
+      },
+      {
+        "internalType": "contract IHook",
+        "name": "hook",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "validatorData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "hookData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "initConfig",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "moduleType",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "initData",
+        "type": "bytes"
+      }
+    ],
+    "name": "installModule",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ValidationId[]",
+        "name": "vIds",
+        "type": "bytes21[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "nonce",
+            "type": "uint32"
+          },
+          {
+            "internalType": "contract IHook",
+            "name": "hook",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct ValidationManager.ValidationConfig[]",
+        "name": "configs",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "validationData",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "hookData",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "installValidations",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "nonce",
+        "type": "uint32"
+      }
+    ],
+    "name": "invalidateNonce",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ValidationId",
+        "name": "vId",
+        "type": "bytes21"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      }
+    ],
+    "name": "isAllowedSelector",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "moduleType",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "additionalContext",
+        "type": "bytes"
+      }
+    ],
+    "name": "isModuleInstalled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "hash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "isValidSignature",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "PermissionId",
+        "name": "pId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "permissionConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "PassFlag",
+            "name": "permissionFlag",
+            "type": "bytes2"
+          },
+          {
+            "internalType": "contract ISigner",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "PolicyData[]",
+            "name": "policyData",
+            "type": "bytes22[]"
+          }
+        ],
+        "internalType": "struct ValidationManager.PermissionConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rootValidator",
+    "outputs": [
+      {
+        "internalType": "ValidationId",
+        "name": "",
+        "type": "bytes21"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      }
+    ],
+    "name": "selectorConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IHook",
+            "name": "hook",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "CallType",
+            "name": "callType",
+            "type": "bytes1"
+          }
+        ],
+        "internalType": "struct SelectorManager.SelectorConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ExecMode",
+        "name": "mode",
+        "type": "bytes32"
+      }
+    ],
+    "name": "supportsExecutionMode",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "moduleTypeId",
+        "type": "uint256"
+      }
+    ],
+    "name": "supportsModule",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "moduleType",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "module",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "deInitData",
+        "type": "bytes"
+      }
+    ],
+    "name": "uninstallModule",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ValidationId",
+        "name": "vId",
+        "type": "bytes21"
+      },
+      {
+        "internalType": "bytes",
+        "name": "deinitData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "hookDeinitData",
+        "type": "bytes"
+      }
+    ],
+    "name": "uninstallValidation",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "validNonceFrom",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "initCode",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "accountGasLimits",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "preVerificationGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "gasFees",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes",
+            "name": "paymasterAndData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PackedUserOperation",
+        "name": "userOp",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "userOpHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "missingAccountFunds",
+        "type": "uint256"
+      }
+    ],
+    "name": "validateUserOp",
+    "outputs": [
+      {
+        "internalType": "ValidationData",
+        "name": "validationData",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "ValidationId",
+        "name": "vId",
+        "type": "bytes21"
+      }
+    ],
+    "name": "validationConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "nonce",
+            "type": "uint32"
+          },
+          {
+            "internalType": "contract IHook",
+            "name": "hook",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct ValidationManager.ValidationConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/abis/index.ts
+++ b/src/abis/index.ts
@@ -3,3 +3,5 @@ export { default as BlastNegRiskCtfExchangeAbi } from "./BlastNegRiskCtfExchange
 export { default as BlastNegRiskAdapterAbi } from "./BlastNegRiskAdapter.json";
 export { default as BlastConditionalTokensAbi } from "./BlastConditionalTokens.json";
 export { default as ERC20Abi } from "./ERC20.json";
+export { default as KernelAbi } from "./Kernel.json";
+export { default as ECDSAValidatorAbi } from "./ECDSAValidator.json";

--- a/src/internal/Utils.ts
+++ b/src/internal/Utils.ts
@@ -1,0 +1,26 @@
+import type { BaseContract, BaseWallet, InterfaceAbi, Provider, TypedDataDomain } from "ethers";
+import { AbiCoder, concat, Contract, hexlify, Interface, keccak256, TypedDataEncoder } from "ethers";
+
+export function makeContract<T extends BaseContract>(address: string, abi: InterfaceAbi) {
+  return (signerOrProvider: BaseWallet | Provider): { contract: T; codec: Interface } => {
+    const codec = new Interface(abi);
+    const contract = new Contract(address, codec).connect(signerOrProvider) as T;
+
+    return { contract, codec };
+  };
+}
+
+export function hashKernelMessage(messageHash: string) {
+  const codec = new AbiCoder();
+  const encoder = new TextEncoder();
+
+  const value = encoder.encode("Kernel(bytes32 hash)");
+  return keccak256(codec.encode(["bytes32", "bytes32"], [keccak256(hexlify(value)), messageHash]));
+}
+
+export function eip712WrapHash(messageHash: string, domain: TypedDataDomain) {
+  const domainSeparator = TypedDataEncoder.hashDomain(domain);
+  const finalMessageHash = hashKernelMessage(messageHash);
+
+  return keccak256(concat(["0x1901", domainSeparator, finalMessageHash]));
+}

--- a/tests/OrderBuilder.test.ts
+++ b/tests/OrderBuilder.test.ts
@@ -15,7 +15,11 @@ const toWei = (amount: number) => parseEther(amount.toString());
 const generateSalt = () => "1234";
 
 describe("OrderBuilder", () => {
-  const orderBuilder = new OrderBuilder(ChainId.BlastSepolia, mockSigner, { generateSalt });
+  let orderBuilder: OrderBuilder;
+
+  beforeAll(async () => {
+    orderBuilder = await OrderBuilder.make(ChainId.BlastSepolia, mockSigner, { generateSalt });
+  });
 
   describe("getLimitOrderAmounts", () => {
     it("should calculate correct amounts for BUY order", () => {
@@ -197,7 +201,7 @@ describe("OrderBuilder", () => {
     });
 
     it("should throw MissingSignerError if signer is not provided", async () => {
-      const orderBuilderWithoutSigner = new OrderBuilder(ChainId.BlastSepolia);
+      const orderBuilderWithoutSigner = await OrderBuilder.make(ChainId.BlastSepolia);
       const order = orderBuilderWithoutSigner.buildOrder("LIMIT", {
         side: Side.BUY,
         nonce: "1",


### PR DESCRIPTION
This PR adds utils for Predict Accounts to facilitate operations like signatures and transactions via Predict smart wallets.

**NOTE**: This includes breaking changes to the `OrderBuilder`, which now needs to be initialised via the async `make` method.