### PR TITLE
docs: fix Constants.ts deep link to use a GitHub line anchor (#L32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Predict supports interacting with the protocol using either a traditional Extern
 
 Before trading, you need to set approvals for ERC-1155 (`ConditionalTokens`) and ERC-20 (`USDT`). This can be achieved by sending a transaction to the respective contracts (see the [Contracts](#contracts) section) and approving both the `CTF_EXCHANGE` and the `NEG_RISK_CTF_EXCHANGE` or via the SDK utils.
 
-**Contracts**: The current deployed contracts can be found either in the [`Constants.ts`](./src/Constants.ts#32) file or in the [Deployed Contracts](https://docs.predict.fun/developers/deployed-contracts) documentation.
+**Contracts**: The current deployed contracts can be found either in the [`Constants.ts`](./src/Constants.ts#L32) file or in the [Deployed Contracts](https://docs.predict.fun/developers/deployed-contracts) documentation.
 
 The following example demonstrates how to set the necessary approvals using the SDK utils.
 


### PR DESCRIPTION
## Problem

The **How to set approvals** section links to the deployed-contracts constant:

```md
The current deployed contracts can be found either in the [`Constants.ts`](./src/Constants.ts#32) file ...
```

GitHub line anchors need an `L` prefix (`#L32`). As written, `#32` isn't a valid line fragment, so it's ignored and the link opens `Constants.ts` at the top rather than at the intended line.

Line 32 of `src/Constants.ts` is `export const AddressesByChainId = {` — exactly the declaration the sentence is pointing at, so the intent is clear.

## Fix

```diff
-[`Constants.ts`](./src/Constants.ts#32)
+[`Constants.ts`](./src/Constants.ts#L32)
```

One-character docs fix; the link now jumps to the contract-address map.

(Worth noting: line-number anchors drift as the file changes. If you'd prefer something stable, a permalink pinned to a commit or a link to the symbol would both survive edits — happy to switch if you like.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fix with no runtime or API impact.
> 
> **Overview**
> Updates the **How to set approvals** link to `Constants.ts` so it uses GitHub’s `#L32` line anchor instead of `#32`, which GitHub ignores.
> 
> Readers following the **Contracts** bullet now land on the `AddressesByChainId` export instead of the top of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6aa7aa25c53249267afc7d4f0a33878246fbcc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->