### PR TITLE
fix(sdk): harden order salt randomness, explicit signer resolution, and cancellation safety

### DIFF
--- a/src/OrderBuilder.ts
+++ b/src/OrderBuilder.ts
@@ -53,9 +53,11 @@ import type { ContractFunction, Optional } from "./internal/Types";
 import {
   concat,
   hashMessage,
+  hexlify,
   MaxInt256,
   MaxUint256,
   parseEther,
+  randomBytes,
   toBeHex,
   TypedDataEncoder,
   ZeroAddress,
@@ -117,12 +119,24 @@ interface OrderBuilderOptions {
 }
 
 /**
- * Default function to generate a random salt for the order.
+ * Generate an unpredictable salt for an order.
  *
- * @returns {string} A random numeric string value for the salt.
+ * Rejection sampling avoids the modulo bias that would otherwise be introduced
+ * when a 32-bit random value is reduced to the protocol's salt range.
+ *
+ * @returns A cryptographically random numeric string value for the salt.
  */
 export const generateOrderSalt = (): string => {
-  return String(Math.round(Math.random() * MAX_SALT));
+  const saltRange = BigInt(MAX_SALT) + 1n;
+  const randomRange = 1n << 32n;
+  const maxAccepted = randomRange - (randomRange % saltRange);
+
+  let sample: bigint;
+  do {
+    sample = BigInt(hexlify(randomBytes(4)));
+  } while (sample >= maxAccepted);
+
+  return String(sample % saltRange);
 };
 
 /**
@@ -1016,8 +1030,12 @@ export class OrderBuilder {
       throw new InvalidExpirationError();
     }
 
-    const signer = data?.signer ?? this.signer!.address;
-    if (data?.maker && signer !== data.maker) {
+    const signer = data?.signer ?? this.signer?.address ?? this.predictAccount;
+    if (!signer) {
+      throw new MissingSignerError();
+    }
+
+    if (!this.predictAccount && data?.maker && signer !== data.maker) {
       throw new MakerSignerMismatchError();
     }
 

--- a/tests/OrderBuilder.test.ts
+++ b/tests/OrderBuilder.test.ts
@@ -487,6 +487,41 @@ describe("OrderBuilder", () => {
         }),
       ).toThrow(InvalidExpirationError);
     });
+
+    it("should throw MissingSignerError when no signer is available", () => {
+      const builderWithoutSigner = OrderBuilder.make(ChainId.BnbMainnet);
+
+      expect(() =>
+        builderWithoutSigner.buildOrder("LIMIT", {
+          side: Side.BUY,
+          tokenId: "123",
+          makerAmount: toWei(10),
+          takerAmount: toWei(5),
+          feeRateBps: 0,
+        }),
+      ).toThrow(MissingSignerError);
+    });
+
+    it("should use the Predict account for maker and signer fields", () => {
+      const predictAccount = "0x1111111111111111111111111111111111111111";
+      const builder = OrderBuilder.make(ChainId.BnbMainnet, undefined, {
+        generateSalt,
+        predictAccount,
+      });
+
+      const order = builder.buildOrder("LIMIT", {
+        side: Side.BUY,
+        signer: "0xsigner",
+        maker: "0xmaker",
+        tokenId: "123",
+        makerAmount: toWei(10),
+        takerAmount: toWei(5),
+        feeRateBps: 0,
+      });
+
+      expect(order.maker).toBe(predictAccount);
+      expect(order.signer).toBe(predictAccount);
+    });
   });
 
   const _correctTypedDataTest = (isNegRisk: boolean, isYieldBearing: boolean) => {


### PR DESCRIPTION
### Description
This PR hardens the TypeScript SDK core order builder and cancellation paths against predictable order identifiers, implicit non-null assertions, and missing signer contracts[cite: 37]. It introduces cryptographic randomness for order salts, ensures fail-fast error handling for unassigned signers, and preserves zero-salt semantics[cite: 37].

### Key Changes
* **Cryptographic Order Salts (`sdk/src/OrderBuilder.ts`, `sdk-python/...`):** 
  - Replaced non-cryptographic pseudo-random number generators (`Math.random()` / `random.randint`) with cryptographically secure random bytes and rejection sampling to completely eliminate modulo bias[cite: 37].
* **Explicit Signer Resolution (`sdk/src/OrderBuilder.ts`):** 
  - Replaced unsafe non-null assertions (`this.signer!.address`) with strict typed failure handling, ensuring `MissingSignerError` is thrown predictably before any property dereference[cite: 37].
* **Predict-Account & Maker/Signer Semantics (`sdk/tests/OrderBuilder.test.ts`):** 
  - Added robust test coverage confirming correct maker/signer precedence and fallback behaviors when utilizing Predict accounts[cite: 37].

### Validation & Testing
* **TypeScript Quality Gates:** Successfully passed `yarn typecheck`, `yarn lint`, and the full TypeScript regression suite (`yarn test` / Jest on-chain/unit tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how every default order gets its salt and how maker/signer are chosen before signing; incorrect resolution could break order submission, but scope is limited to `buildOrder` and `generateOrderSalt`.
> 
> **Overview**
> **Default order salts** now come from `ethers` `randomBytes` with rejection sampling into `[0, MAX_SALT]`, replacing `Math.random()` so salts are unpredictable and not modulo-biased.
> 
> **`buildOrder`** resolves the signing identity as `data.signer` → connected wallet address → `predictAccount`, and throws **`MissingSignerError`** when none exist instead of using `this.signer!.address`. **Maker/signer mismatch** is enforced only for non–Predict-account builders; Predict-account mode still forces **maker** and **signer** to the predict account.
> 
> Tests add coverage for missing-signer failure and Predict-account maker/signer fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404fa5904c2361f433660be212febba8ca1918be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->